### PR TITLE
Add responsive sizing media queries

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,8 @@
+:root {
+    --card-width: 100px;
+    --card-height: 150px;
+}
+
 body {
     font-family: sans-serif;
     background-color: #f0f0f0;
@@ -76,8 +81,8 @@ main {
 }
 
 .deck {
-    width: 100px;
-    height: 150px;
+    width: var(--card-width);
+    height: var(--card-height);
     border: 3px solid #333;
     border-radius: 10px;
     margin: 1rem auto;
@@ -109,8 +114,8 @@ main {
 }
 
 .card-slot {
-    width: 100px;
-    height: 150px;
+    width: var(--card-width);
+    height: var(--card-height);
     border: 2px dashed #ccc;
     border-radius: 10px;
     margin: 0 2rem;
@@ -209,11 +214,36 @@ main {
         flex-direction: row;
     }
 }
+@media (max-width: 480px) {
+    :root {
+        --card-width: 70px;
+        --card-height: 105px;
+    }
+
+    .card-slot {
+        margin: 0 1rem;
+    }
+    .played-cards {
+        margin: 0.5rem 0;
+    }
+}
+
+@media (min-width: 900px) {
+    :root {
+        --card-width: 120px;
+        --card-height: 180px;
+    }
+
+    .player-section {
+        width: 32%;
+    }
+}
+
 
 .card {
     position: relative;
-    width: 100px;
-    height: 150px;
+    width: var(--card-width);
+    height: var(--card-height);
     border: 1px solid #000;
     border-radius: 10px;
     background-color: white;


### PR DESCRIPTION
## Summary
- introduce CSS variables for card sizing
- use variables for card, deck, and card-slot dimensions
- add responsive breakpoints at 480px and 900px that update card size and layout

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68611f4ab280832f918c4a2a65113993