### PR TITLE
Improve responsive board layout

### DIFF
--- a/style.css
+++ b/style.css
@@ -60,13 +60,15 @@ main {
 
 #game-board {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 1rem;
     width: 100%;
 }
 
 .player-section {
-    width: 30%;
+    flex: 1 1 250px;
     text-align: center;
     padding: 1rem;
     border: 2px solid #ccc;
@@ -96,7 +98,7 @@ main {
 }
 
 .center-area {
-    width: 35%;
+    flex: 2 1 300px;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -200,13 +202,25 @@ main {
         flex-direction: column;
     }
 
-    .player-section, .center-area {
-        width: 90%;
+    .player-section,
+    .center-area {
+        flex-basis: 100%;
         margin-bottom: 1rem;
     }
 
     .played-cards {
         flex-direction: row;
+    }
+}
+
+@media (min-width: 601px) and (max-width: 900px) {
+    #game-board {
+        justify-content: center;
+    }
+
+    .player-section,
+    .center-area {
+        flex: 1 1 45%;
     }
 }
 


### PR DESCRIPTION
## Summary
- use flexbox with wrapping for the game board layout
- make board columns flexible with `flex: 1` sizing
- refine phone and tablet breakpoints

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68611f4b66ec832f8a6f2012ec903953